### PR TITLE
Fix API permission scope names in README

### DIFF
--- a/custom-iom/README.md
+++ b/custom-iom/README.md
@@ -207,9 +207,9 @@ custom-iom/
 ### API Permissions Required
 
 Your Falcon API client needs these scopes:
-- `cloud-security-assessment:read` - For asset discovery
-- `cloud-policies:read` - For reading existing policies
-- `cloud-policies:write` - For creating Custom IOMs
+- `Cloud Security API Assets:READ` - For asset discovery
+- `Cloud Security Policies:READ` - For reading existing policies
+- `Cloud Security Policies:WRITE` - For creating Custom IOMs
 
 ### Setting Up Credentials
 


### PR DESCRIPTION
Update to use correct CrowdStrike API scope names:
- Cloud Security API Assets:READ (for asset discovery)
- Cloud Security Policies:READ (for reading existing policies)
- Cloud Security Policies:WRITE (for creating Custom IOMs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)