### PR TITLE
Add Insights report, subdomain classification, and CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CSPM Policy Report Generator
 
-Scripts to retrieve and export CrowdStrike CSPM (Cloud Security Posture Management) policy details via the Falcon API. Generates four separate CSV reports covering **IOMs** (cloud misconfigurations), **IOAs** (behavioral detections), **IAC rules** (infrastructure-as-code / container / API security), and **Cloud Risks** (toxic combinations).
+Scripts to retrieve and export CrowdStrike CSPM (Cloud Security Posture Management) policy details via the Falcon API. Generates five separate CSV reports covering **IOMs** (cloud misconfigurations), **IOAs** (behavioral detections), **Insights** (identity, exposure, sensitivity, and ASPM), **IAC rules** (infrastructure-as-code / container / API security), and **Cloud Risks** (toxic combinations).
 
 ## Overview
 
@@ -8,7 +8,8 @@ This tool generates comprehensive CSV reports of all CSPM policies in your Crowd
 
 - **IOM Report** — Indicators of Misconfiguration (default and custom cloud configuration policies)
 - **IOA Report** — Indicators of Attack (behavioral detection policies with MITRE ATT&CK-aligned attack types)
-- **IAC Report** — Infrastructure-as-Code rules (Kubernetes, Docker, Helm, OpenAPI/Swagger, ASPM, and other non-cloud-native policies)
+- **Insights Report** — Identity risk, internet exposure, sensitive data, backup status, and ASPM application insights
+- **IAC Report** — Infrastructure-as-Code rules (Kubernetes, Docker, Helm, OpenAPI/Swagger, and other scanning rules)
 - **Cloud Risks Report** — Cloud security risks / toxic combinations (deduplicated rules with finding counts)
 
 ## Quick Start
@@ -71,88 +72,91 @@ python3 get-cspm-rules.py
 bash get-cspm-rules.sh
 ```
 
+### Options
+
+| Flag | Description |
+|---|---|
+| `--provider VALUE` | Filter all reports to a specific cloud provider (e.g., `AWS`, `Azure`, `GCP`, `OCI`) |
+| `--sort-by-id` | Sort rows by Policy ID / Rule ID |
+
+```bash
+# Export only AWS policies, sorted by ID
+python3 get-cspm-rules.py --provider AWS --sort-by-id
+
+# Export only Azure policies
+bash get-cspm-rules.sh --provider Azure
+```
+
 Both scripts will:
 1. Authenticate with the Falcon API
-2. Fetch `settings/entities/policy/v1` to get IOA (Behavioral) policies and build a Configuration policy name list for classification
+2. Fetch `settings/entities/policy/v1` to get IOA (Behavioral) policies
 3. Retrieve all cloud-policy IDs via `cloud-policies/queries/rules/v1` (with pagination)
 4. Fetch detailed cloud-policy information in batches via `cloud-policies/entities/rules/v1`
-5. Classify each cloud-policy as **IOM** (exists in settings Configuration) or **IAC** (does not)
+5. Classify each cloud-policy by its `subdomain` field: **IOM**, **Insight**, or **IAC**
 6. Fetch cloud risks via `cloud-security-risks/combined/cloud-risks/v1` and deduplicate by rule
-7. Generate four timestamped CSV files and display summary statistics
+7. Generate five timestamped CSV files and display summary statistics
 
 ### Output Files
 
-| File | Contents | 
+| File | Contents |
 |---|---|
-| `cspm_iom_report_TIMESTAMP.csv` | Cloud misconfigurations (AWS, Azure, GCP, OCI)
-| `cspm_ioa_report_TIMESTAMP.csv` | Behavioral detections (AWS, Azure) 
-| `cspm_iac_report_TIMESTAMP.csv` | IAC / container / API security rules
-| `cspm_cloud_risks_report_TIMESTAMP.csv` | Cloud risks / toxic combinations 
+| `cspm_iom_report_TIMESTAMP.csv` | Cloud misconfigurations (AWS, Azure, GCP, OCI) |
+| `cspm_ioa_report_TIMESTAMP.csv` | Behavioral detections (AWS, Azure) |
+| `cspm_insights_report_TIMESTAMP.csv` | Identity, exposure, sensitivity, and ASPM insights |
+| `cspm_iac_report_TIMESTAMP.csv` | IAC / container / API security scanning rules |
+| `cspm_cloud_risks_report_TIMESTAMP.csv` | Cloud risks / toxic combinations |
 
-### Performance Comparison
-
-| | Python | Bash |
-|---|---|---|
-| Batch size | 100 | 25 |
-| Concurrency | 5 parallel workers | Sequential |
-| Typical runtime | ~9 seconds | ~2.5 minutes |
-| Dependencies | python3 (stdlib only) | curl, jq, python3 |
-
-## CSV Columns
-
-### IOM / IOA / IAC Reports
-
-| Column | Description | IOMs | IOAs | IAC |
-|--------|-------------|------|------|-----|
-| **Policy ID** | Unique identifier (UUID for IOMs/IAC, integer for IOAs) | Yes | Yes | Yes |
-| **Policy Name** | Human-readable policy name | Yes | Yes | Yes |
-| **Cloud Provider** | AWS, Azure, GCP, OCI, General, ASPM | Yes | Yes | Yes |
-| **Resource Type** | Cloud resource type or asset type | Yes | Yes | Yes |
-| **Service** | Cloud service category (e.g., S3, EC2, Identity) | Yes | Yes | Yes |
-| **Origin** | `Default` or `Custom` | Yes | Yes | Yes |
-| **Policy Type** | `IOM`, `IOA`, or `IAC` | Yes | Yes | Yes |
-| **Description** | Detailed policy description | Yes | — | Yes |
-| **Alert Logic** | Step-by-step detection logic | Yes | — | Yes |
-| **Remediation Steps** | How to remediate findings | Yes | — | Yes |
-| **Attack Types** | MITRE-aligned attack categories | — | Yes | — |
-
-### Cloud Risks Report
-
-| Column | Description |
-|--------|-------------|
-| **Rule ID** | Unique rule identifier (UUID) |
-| **Rule Name** | Human-readable rule name (e.g., "Unused identity with excessive permissions") |
-| **Severity** | `Low`, `Medium`, or `High` |
-| **Cloud Provider** | AWS, Azure, GCP (semicolon-separated if multiple) |
-| **Service Category** | Identity, Compute, Data, etc. |
-| **Insight Categories** | Identity, Network, Vulnerabilities, Data, etc. |
-| **Risk Factors** | Contributing risk factors (e.g., "Unused Identity; Excessive infra permissions") |
-| **Description** | Detailed rule description |
-| **Finding Count** | Total number of findings for this rule |
-| **Open Count** | Number of currently open findings |
-| **Resolved Count** | Number of resolved findings |
 
 ## How Classification Works
 
-The script uses a cross-reference approach to separate cloud IOMs from IAC rules:
+Each cloud-policy from the `/cloud-policies/entities/rules/v1` endpoint includes a `subdomain` field that the script uses for classification:
 
-1. **IOAs**: Policies from `settings/entities/policy/v1` with `policy_type == "Behavioral"` — these are behavioral detections that don't exist in the cloud-policies endpoint
-2. **IOMs**: Cloud-policies whose name matches a Configuration policy in `settings/entities/policy/v1` — these are cloud-native misconfigurations (e.g., S3 bucket public access, CloudTrail disabled)
-3. **IAC**: Everything else from cloud-policies — Kubernetes, Docker, Helm, OpenAPI/Swagger, ASPM, and other non-cloud-native rules
-4. **Cloud Risks**: Fetched from a separate endpoint (`cloud-security-risks/combined/cloud-risks/v1`) — these are toxic combinations representing multi-factor security risks (e.g., "Unused identity with excessive permissions"). The endpoint returns per-asset findings which are deduplicated by `rule_id` to produce unique rules
+| `subdomain` value | Report | Description |
+|---|---|---|
+| `IOM` | IOM CSV | Cloud-native misconfigurations (e.g., S3 bucket public access, CloudTrail disabled) |
+| `Insight` | Insights CSV | Identity risk, internet exposure, sensitive data detection, ASPM application insights |
+| `IAC` | IAC CSV | Infrastructure-as-code scanning rules (Kubernetes, Docker, Helm, OpenAPI/Swagger) |
+| `CloudRisk` | (skipped) | Covered by the dedicated cloud-risks endpoint instead |
 
+Additionally:
+- **IOAs**: Fetched from a separate endpoint (`settings/entities/policy/v1`) with `policy_type == "Behavioral"` — behavioral detections that don't exist in the cloud-policies endpoint
+- **Cloud Risks**: Fetched from `cloud-security-risks/combined/cloud-risks/v1` — toxic combinations representing multi-factor security risks. The endpoint returns per-asset findings which are deduplicated by `rule_id` to produce unique rules
+
+## API Endpoints Used
+
+### `GET /cloud-policies/queries/rules/v1`
+Returns paginated IDs for all cloud-policies. Used to enumerate every policy before fetching details.
+- **Pagination**: `limit` (max 500) + `offset`
+- **Returns**: Array of UUID strings
+
+### `GET /cloud-policies/entities/rules/v1`
+Returns full policy details for a batch of IDs. This is the primary data source for **IOM**, **Insight**, and **IAC** reports.
+- **Parameters**: `ids` (pass multiple)
+- **Key fields**: `uuid`, `name`, `provider`, `subdomain`, `description`, `alert_info`, `remediation`, `resource_types`, `origin`
+- **Classification**: The `subdomain` field determines the report — `"IOM"`, `"Insight"`, `"IAC"`, or `"CloudRisk"`
+
+### `GET /settings/entities/policy/v1`
+Returns all CSPM settings policies in a single response (no pagination). Used exclusively for the **IOA** report.
+- **Filter**: `policy_type == "Behavioral"` selects IOA policies
+- **Key fields**: `policy_id`, `name`, `cloud_provider`, `cloud_asset_type`, `cloud_service_friendly`, `attack_types`
+
+### `GET /cloud-security-risks/combined/cloud-risks/v1`
+Returns per-asset cloud risk findings. Used for the **Cloud Risks** report after deduplication by `rule_id`.
+- **Pagination**: `limit` (max 1000) + `offset`
+- **Key fields**: `rule_id`, `rule_name`, `rule_description`, `severity`, `provider`, `service_category`, `risk_factors`, `status`
+- **Deduplication**: Multiple findings per rule (one per affected asset) — the script aggregates to unique rules with open/resolved counts
 
 ## API Permissions Required
 
 Your Falcon API client needs the following scopes:
-- `Cloud Security Policies:read` — for IOM and IAC policies
-- `Cloud Security API Risks:read` — for IOA (Behavioral) policies and IOM classification
+- `Cloud Security Policies:read` — for IOM, Insight, and IAC policies
+- `Cloud Security API Risks:read` — for IOA (Behavioral) policies and Cloud Risks
 
 ## Troubleshooting
 
 ### Authentication Issues
 - Verify your `FALCON_CLIENT_ID` and `FALCON_CLIENT_SECRET` are correct
-- Ensure your API client has the required permissions (all three scopes listed above)
+- Ensure your API client has the required permissions (both scopes listed above)
 
 ### Non-US-1 Cloud Regions
 Set the `FALCON_BASE_URL` environment variable to your region's API base URL:

--- a/get-cspm-rules.py
+++ b/get-cspm-rules.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 """
-CSPM Policy Report - IOMs, IOAs, IAC Rules, and Cloud Risks
-Generates four separate CSV reports:
+CSPM Policy Report - IOMs, IOAs, Insights, IAC Rules, and Cloud Risks
+Generates five separate CSV reports:
   - IOM: Cloud misconfigurations (default + custom)
   - IOA: Behavioral detections (indicators of attack)
+  - Insights: Identity, exposure, sensitivity, and ASPM insights
   - IAC: Infrastructure-as-code / container / API security rules
   - Cloud Risks: Toxic combinations / cloud security risks
 Uses concurrent requests for fast execution.
 """
 
+import argparse
 import csv
 import json
 import os
@@ -81,24 +83,19 @@ def api_get(token, path):
 
 
 # ──────────────────────────────────────────────
-# Settings endpoint (classification + IOAs)
+# Settings endpoint (IOAs)
 # ──────────────────────────────────────────────
 
-def get_settings_policies(token):
-    """Fetch settings/entities/policy/v1. Returns (config_names, ioa_rows)."""
-    print("📋 Fetching settings policies for classification...")
+def get_ioa_policies(token):
+    """Fetch settings/entities/policy/v1. Returns ioa_rows."""
+    print("📋 Fetching settings policies for IOAs...")
     data = api_get(token, "/settings/entities/policy/v1")
     resources = data.get("resources", [])
 
-    # Build set of Configuration policy names — used to classify cloud-policies
-    config_names = set()
     ioa_rows = []
 
     for r in resources:
-        ptype = r.get("policy_type", "")
-        if ptype == "Configuration":
-            config_names.add(r.get("name", ""))
-        elif ptype == "Behavioral":
+        if r.get("policy_type", "") == "Behavioral":
             provider = r.get("cloud_provider", "")
             provider = PROVIDER_MAP.get(provider, provider.upper())
             attack_types = "; ".join(r.get("attack_types") or [])
@@ -116,12 +113,12 @@ def get_settings_policies(token):
                 attack_types,
             ])
 
-    print(f"✅ Settings: {len(config_names)} Configuration names, {len(ioa_rows)} IOAs")
-    return config_names, ioa_rows
+    print(f"✅ Settings: {len(ioa_rows)} IOAs")
+    return ioa_rows
 
 
 # ──────────────────────────────────────────────
-# Cloud-policies endpoint (IOMs + IAC)
+# Cloud-policies endpoint (IOMs, Insights, IAC)
 # ──────────────────────────────────────────────
 
 def get_cloud_policy_ids(token):
@@ -146,12 +143,13 @@ def get_cloud_policy_ids(token):
 
 
 def fetch_cloud_policy_batch(token, batch_ids, batch_num, total_batches):
-    """Fetch a single batch of cloud-policy details. Returns list of (name, row) tuples."""
+    """Fetch a single batch of cloud-policy details. Returns list of (subdomain, row) tuples."""
     params = "&".join(f"ids={uid}" for uid in batch_ids)
     data = api_get(token, f"/cloud-policies/entities/rules/v1?{params}")
     results = []
     for r in data.get("resources", []):
         name = r.get("name", "")
+        subdomain = r.get("subdomain", "")
         for rt in r.get("resource_types", [{}]):
             desc = (r.get("description") or "").replace("\n", " ")
             alert = (r.get("alert_info") or "").replace("\n", " ").replace("|", " - ")
@@ -169,7 +167,7 @@ def fetch_cloud_policy_batch(token, batch_ids, batch_num, total_batches):
                 remed,
                 "",
             ]
-            results.append((name, row))
+            results.append((subdomain, row))
     return batch_num, len(data.get("resources", [])), results
 
 
@@ -293,20 +291,44 @@ def print_breakdown(label, rows, idx):
 # ──────────────────────────────────────────────
 
 def main():
+    parser = argparse.ArgumentParser(
+        description="Generate CSPM policy reports from the CrowdStrike Falcon API.",
+    )
+    parser.add_argument(
+        "--provider",
+        help="Filter results to a specific cloud provider (e.g., AWS, Azure, GCP, OCI)",
+    )
+    parser.add_argument(
+        "--sort-by-id",
+        action="store_true",
+        help="Sort rows by Policy ID / Rule ID instead of the default order",
+    )
+    args = parser.parse_args()
+
+    provider_filter = args.provider.upper() if args.provider else None
+    # Normalise common aliases so "aws" matches "AWS", etc.
+    if provider_filter:
+        provider_filter = PROVIDER_MAP.get(provider_filter.lower(), provider_filter)
+
     start_time = time.time()
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     iom_file = f"cspm_iom_report_{timestamp}.csv"
     ioa_file = f"cspm_ioa_report_{timestamp}.csv"
+    insight_file = f"cspm_insights_report_{timestamp}.csv"
     iac_file = f"cspm_iac_report_{timestamp}.csv"
     risk_file = f"cspm_cloud_risks_report_{timestamp}.csv"
 
-    print("🚀 CSPM Policy Report — IOMs + IOAs + IAC + Cloud Risks")
-    print("=" * 56)
+    print("🚀 CSPM Policy Report — IOMs + IOAs + Insights + IAC + Cloud Risks")
+    print("=" * 66)
+    if provider_filter:
+        print(f"   Provider filter: {provider_filter}")
+    if args.sort_by_id:
+        print("   Sort: by Policy/Rule ID")
 
     token = get_bearer_token()
 
-    # Step 1: Fetch settings policies (for classification + IOAs)
-    config_names, ioa_rows = get_settings_policies(token)
+    # Step 1: Fetch IOA (Behavioral) policies from settings
+    ioa_rows = get_ioa_policies(token)
 
     print()
     print("─" * 38)
@@ -316,16 +338,20 @@ def main():
     cp_ids = get_cloud_policy_ids(token)
     cp_results = get_all_cloud_policies(token, cp_ids)
 
-    # Step 3: Classify cloud-policies into IOM vs IAC
+    # Step 3: Classify cloud-policies by subdomain
     iom_rows = []
+    insight_rows = []
     iac_rows = []
-    for name, row in cp_results:
-        if name in config_names:
-            row[6] = "IOM"
-            iom_rows.append(row)
-        else:
+    for subdomain, row in cp_results:
+        if subdomain == "Insight":
+            row[6] = "Insight"
+            insight_rows.append(row)
+        elif subdomain == "IAC":
             row[6] = "IAC"
             iac_rows.append(row)
+        else:
+            row[6] = "IOM"
+            iom_rows.append(row)
 
     # Step 4: Fetch cloud risks (toxic combinations)
     print()
@@ -333,9 +359,28 @@ def main():
     print()
     risk_rows = get_cloud_risks(token)
 
-    # Step 5: Write CSVs
+    # Step 5: Apply filters and sorting
+    if provider_filter:
+        print()
+        print(f"🔍 Filtering to provider: {provider_filter}")
+        iom_rows = [r for r in iom_rows if r[2].upper() == provider_filter.upper()]
+        ioa_rows = [r for r in ioa_rows if r[2].upper() == provider_filter.upper()]
+        insight_rows = [r for r in insight_rows if r[2].upper() == provider_filter.upper()]
+        iac_rows = [r for r in iac_rows if r[2].upper() == provider_filter.upper()]
+        # Cloud Risks: provider column (idx 3) is semicolon-separated
+        risk_rows = [r for r in risk_rows if provider_filter.upper() in str(r[3]).upper()]
+
+    if args.sort_by_id:
+        iom_rows.sort(key=lambda r: r[0])
+        ioa_rows.sort(key=lambda r: r[0])
+        insight_rows.sort(key=lambda r: r[0])
+        iac_rows.sort(key=lambda r: r[0])
+        risk_rows.sort(key=lambda r: r[0])
+
+    # Step 6: Write CSVs
     write_csv(iom_file, iom_rows)
     write_csv(ioa_file, ioa_rows)
+    write_csv(insight_file, insight_rows)
     write_csv(iac_file, iac_rows)
     write_csv(risk_file, risk_rows, headers=CLOUD_RISK_HEADERS)
 
@@ -350,6 +395,7 @@ def main():
     for label, filepath, rows in [
         ("IOM (Cloud Misconfigurations)", iom_file, iom_rows),
         ("IOA (Behavioral Detections)", ioa_file, ioa_rows),
+        ("Insights (Identity/Exposure/ASPM)", insight_file, insight_rows),
         ("IAC (Infrastructure-as-Code)", iac_file, iac_rows),
     ]:
         print(f"📄 {label}: {filepath} ({len(rows)} rows)")
@@ -362,7 +408,7 @@ def main():
     print_breakdown("Service Category", risk_rows, 4)
     print()
 
-    total = len(iom_rows) + len(ioa_rows) + len(iac_rows) + len(risk_rows)
+    total = len(iom_rows) + len(ioa_rows) + len(insight_rows) + len(iac_rows) + len(risk_rows)
     print(f"📊 Total across all reports: {total}")
 
 

--- a/get-cspm-rules.sh
+++ b/get-cspm-rules.sh
@@ -1,28 +1,59 @@
 #!/bin/bash
 
-# CSPM Policy Report - IOMs, IOAs, IAC Rules, and Cloud Risks
-# Generates four separate CSV reports:
+# CSPM Policy Report - IOMs, IOAs, Insights, IAC Rules, and Cloud Risks
+# Generates five separate CSV reports:
 #   - IOM: Cloud misconfigurations (default + custom)
 #   - IOA: Behavioral detections (indicators of attack)
+#   - Insights: Identity, exposure, sensitivity, and ASPM insights
 #   - IAC: Infrastructure-as-code / container / API security rules
 #   - Cloud Risks: Toxic combinations / cloud security risks
 
 set -e
+
+# ──────────────────────────────────────────────
+# Parse CLI arguments
+# ──────────────────────────────────────────────
+
+PROVIDER_FILTER=""
+SORT_BY_ID=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --provider)
+            PROVIDER_FILTER="$2"
+            shift 2
+            ;;
+        --sort-by-id)
+            SORT_BY_ID=true
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: bash get-cspm-rules.sh [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  --provider VALUE   Filter results to a specific cloud provider (AWS, Azure, GCP, OCI)"
+            echo "  --sort-by-id       Sort rows by Policy ID / Rule ID"
+            echo "  -h, --help         Show this help message"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
 
 # Configuration
 BATCH_SIZE=25
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 IOM_FILE="cspm_iom_report_${TIMESTAMP}.csv"
 IOA_FILE="cspm_ioa_report_${TIMESTAMP}.csv"
+INSIGHT_FILE="cspm_insights_report_${TIMESTAMP}.csv"
 IAC_FILE="cspm_iac_report_${TIMESTAMP}.csv"
 RISK_FILE="cspm_cloud_risks_report_${TIMESTAMP}.csv"
 CSV_HEADER="Policy ID,Policy Name,Cloud Provider,Resource Type,Service,Origin,Policy Type,Description,Alert Logic,Remediation Steps,Attack Types"
 RISK_CSV_HEADER="Rule ID,Rule Name,Severity,Cloud Provider,Service Category,Insight Categories,Risk Factors,Description,Finding Count,Open Count,Resolved Count"
 BASE_URL="${FALCON_BASE_URL:-https://api.crowdstrike.com}"
-
-# Temp file for settings Configuration names (used for classification)
-CONFIG_NAMES_FILE=$(mktemp)
-trap "rm -f $CONFIG_NAMES_FILE" EXIT
 
 # Check environment variables
 if [[ -z "$FALCON_CLIENT_ID" || -z "$FALCON_CLIENT_SECRET" ]]; then
@@ -50,10 +81,10 @@ fi
 echo "✅ Bearer token retrieved"
 
 # ──────────────────────────────────────────────
-# SECTION 1: Settings (classification + IOAs)
+# SECTION 1: Settings (IOAs)
 # ──────────────────────────────────────────────
 
-echo "📋 Fetching settings policies for classification..."
+echo "📋 Fetching settings policies for IOAs..."
 
 SETTINGS_RESPONSE=$(curl \
     --header "Authorization: Bearer ${BEARER_TOKEN}" \
@@ -61,11 +92,6 @@ SETTINGS_RESPONSE=$(curl \
     --silent \
     --fail \
     "${BASE_URL}/settings/entities/policy/v1")
-
-# Extract Configuration names for classification
-echo "$SETTINGS_RESPONSE" | jq -r '[.resources[] | select(.policy_type == "Configuration")] | .[].name' > "$CONFIG_NAMES_FILE"
-CONFIG_COUNT=$(wc -l < "$CONFIG_NAMES_FILE" | tr -d ' ')
-echo "✅ Settings: $CONFIG_COUNT Configuration names loaded"
 
 # Write IOA CSV
 echo "$CSV_HEADER" > "$IOA_FILE"
@@ -91,7 +117,7 @@ echo "$SETTINGS_RESPONSE" | jq -r '
 echo "   ✅ Processed $IOA_COUNT IOAs"
 
 # ──────────────────────────────────────────────
-# SECTION 2: Cloud-policies (IOMs + IAC)
+# SECTION 2: Cloud-policies (IOMs, Insights, IAC)
 # ──────────────────────────────────────────────
 
 get_cloud_policy_ids() {
@@ -143,6 +169,7 @@ process_cloud_policies() {
 
     # Initialize CSV files
     echo "$CSV_HEADER" > "$IOM_FILE"
+    echo "$CSV_HEADER" > "$INSIGHT_FILE"
     echo "$CSV_HEADER" > "$IAC_FILE"
 
     for ((i=0; i<$total_ids; i+=$BATCH_SIZE)); do
@@ -173,29 +200,31 @@ process_cloud_policies() {
             continue
         fi
 
-        # Classify each policy: name in config names → IOM, else → IAC
-        # Use python for reliable name matching against the config names file
+        # Classify each policy by subdomain field
         echo "$response" | python3 -c "
 import csv, json, sys, io
 
-config_names = set()
-with open('$CONFIG_NAMES_FILE') as f:
-    for line in f:
-        config_names.add(line.strip())
-
 data = json.load(sys.stdin)
 iom_out = io.StringIO()
+insight_out = io.StringIO()
 iac_out = io.StringIO()
 iom_writer = csv.writer(iom_out)
+insight_writer = csv.writer(insight_out)
 iac_writer = csv.writer(iac_out)
 
 for r in data.get('resources', []):
     name = r.get('name', '')
+    subdomain = r.get('subdomain', '')
     for rt in r.get('resource_types', [{}]):
         desc = (r.get('description') or '').replace('\n', ' ')
         alert = (r.get('alert_info') or '').replace('\n', ' ').replace('|', ' - ')
         remed = (r.get('remediation') or '').replace('\n', ' ').replace('|', ' - ')
-        ptype = 'IOM' if name in config_names else 'IAC'
+        if subdomain == 'Insight':
+            ptype = 'Insight'
+        elif subdomain == 'IAC':
+            ptype = 'IAC'
+        else:
+            ptype = 'IOM'
         row = [
             r.get('uuid', ''),
             name,
@@ -206,20 +235,27 @@ for r in data.get('resources', []):
             ptype,
             desc, alert, remed, '',
         ]
-        if ptype == 'IOM':
-            iom_writer.writerow(row)
-        else:
+        if ptype == 'Insight':
+            insight_writer.writerow(row)
+        elif ptype == 'IAC':
             iac_writer.writerow(row)
+        else:
+            iom_writer.writerow(row)
 
 iom_text = iom_out.getvalue()
+insight_text = insight_out.getvalue()
 iac_text = iac_out.getvalue()
 if iom_text:
     sys.stdout.write('IOM:' + iom_text)
+if insight_text:
+    sys.stdout.write('INSIGHT:' + insight_text)
 if iac_text:
     sys.stdout.write('IAC:' + iac_text)
 " | while IFS= read -r line; do
             if [[ "$line" == IOM:* ]]; then
                 echo "${line#IOM:}" >> "$IOM_FILE"
+            elif [[ "$line" == INSIGHT:* ]]; then
+                echo "${line#INSIGHT:}" >> "$INSIGHT_FILE"
             elif [[ "$line" == IAC:* ]]; then
                 echo "${line#IAC:}" >> "$IAC_FILE"
             else
@@ -242,11 +278,17 @@ if iac_text:
 # ──────────────────────────────────────────────
 
 echo ""
-echo "🚀 CSPM Policy Report — IOMs + IOAs + IAC + Cloud Risks"
-echo "===================================================="
+echo "🚀 CSPM Policy Report — IOMs + IOAs + Insights + IAC + Cloud Risks"
+echo "===================================================================="
+if [[ -n "$PROVIDER_FILTER" ]]; then
+    echo "   Provider filter: $PROVIDER_FILTER"
+fi
+if [[ "$SORT_BY_ID" == true ]]; then
+    echo "   Sort: by Policy/Rule ID"
+fi
 echo ""
 
-# Get and process cloud-policies (IOMs + IAC)
+# Get and process cloud-policies (IOMs, Insights, IAC)
 CP_IDS=($(get_cloud_policy_ids))
 process_cloud_policies "${CP_IDS[@]}"
 
@@ -350,6 +392,57 @@ print(f'{len(findings)} findings -> {len(rules)} unique rules', file=sys.stderr)
 " >> "$RISK_FILE"
 
 # ──────────────────────────────────────────────
+# Filter and sort (if requested)
+# ──────────────────────────────────────────────
+
+if [[ -n "$PROVIDER_FILTER" ]] || [[ "$SORT_BY_ID" == true ]]; then
+    echo ""
+    [[ -n "$PROVIDER_FILTER" ]] && echo "🔍 Filtering to provider: $PROVIDER_FILTER"
+    [[ "$SORT_BY_ID" == true ]] && echo "🔃 Sorting by ID"
+
+    python3 -c "
+import csv, sys, os
+
+provider_filter = '$PROVIDER_FILTER'.upper() if '$PROVIDER_FILTER' else None
+sort_by_id = '$SORT_BY_ID' == 'true'
+
+# Provider normalization
+pmap = {'AWS': 'AWS', 'AZURE': 'Azure', 'GCP': 'GCP', 'OCI': 'OCI'}
+if provider_filter:
+    provider_filter = pmap.get(provider_filter, provider_filter)
+
+for filepath in ['$IOM_FILE', '$IOA_FILE', '$INSIGHT_FILE', '$IAC_FILE']:
+    with open(filepath) as f:
+        reader = csv.reader(f)
+        header = next(reader)
+        rows = list(reader)
+    if provider_filter:
+        rows = [r for r in rows if r[2].upper() == provider_filter.upper()]
+    if sort_by_id:
+        rows.sort(key=lambda r: r[0])
+    with open(filepath, 'w', newline='') as f:
+        writer = csv.writer(f)
+        writer.writerow(header)
+        writer.writerows(rows)
+
+# Cloud Risks CSV
+filepath = '$RISK_FILE'
+with open(filepath) as f:
+    reader = csv.reader(f)
+    header = next(reader)
+    rows = list(reader)
+if provider_filter:
+    rows = [r for r in rows if provider_filter.upper() in r[3].upper()]
+if sort_by_id:
+    rows.sort(key=lambda r: r[0])
+with open(filepath, 'w', newline='') as f:
+    writer = csv.writer(f)
+    writer.writerow(header)
+    writer.writerows(rows)
+"
+fi
+
+# ──────────────────────────────────────────────
 # Summary
 # ──────────────────────────────────────────────
 
@@ -362,6 +455,7 @@ import csv, collections
 for label, filepath in [
     ('IOM (Cloud Misconfigurations)', '$IOM_FILE'),
     ('IOA (Behavioral Detections)', '$IOA_FILE'),
+    ('Insights (Identity/Exposure/ASPM)', '$INSIGHT_FILE'),
     ('IAC (Infrastructure-as-Code)', '$IAC_FILE'),
 ]:
     with open(filepath) as f:
@@ -387,7 +481,7 @@ for col_label, key in [('Severity', 'Severity'), ('Service Category', 'Service C
 
 total = sum(
     sum(1 for _ in csv.DictReader(open(f)))
-    for f in ['$IOM_FILE', '$IOA_FILE', '$IAC_FILE', '$RISK_FILE']
+    for f in ['$IOM_FILE', '$IOA_FILE', '$INSIGHT_FILE', '$IAC_FILE', '$RISK_FILE']
 )
 print(f'\n📊 Total across all reports: {total}')
 "


### PR DESCRIPTION
Separate Insights (identity, exposure, ASPM) into their own CSV using the subdomain API field instead of config_names cross-reference. Add --provider and --sort-by-id CLI options to both Python and bash scripts.